### PR TITLE
More Changes

### DIFF
--- a/Example/ContentView.swift
+++ b/Example/ContentView.swift
@@ -107,7 +107,7 @@ struct ContentView: View {
 					EndpointLink<Bool>("Reset Password") { client, completion in
 						client.users.resetPassword(email: keyValueStore.userEmail, completion: completion)
 					}
-					EndpointLink<VoidReply>("Change password") { client, completion in
+					EndpointLink<Zone5.VoidReply>("Change password") { client, completion in
 						if let oldpass = self.me.password {
 							let newpass = "MyNewP@ssword\(Date().milliseconds)"
 							client.users.changePassword(oldPassword: oldpass, newPassword: newpass) { result in
@@ -175,7 +175,7 @@ struct ContentView: View {
 					EndpointLink<OAuthToken>("Get Access Token") { client, completion in
 						client.oAuth.accessToken(username: keyValueStore.userEmail, password: self.password.password, completion: completion)
 					}
-					EndpointLink<VoidReply>("Delete last registered Account (if any)") { client, completion in
+					EndpointLink<Zone5.VoidReply>("Delete last registered Account (if any)") { client, completion in
 						if let id = self.lastRegisteredId {
 							client.users.deleteAccount(userID: id, completion: completion)
 						} else {
@@ -334,7 +334,7 @@ struct ContentView: View {
 						let rego = PushRegistration(token: "1234", platform: "strava", deviceId: "gwjh4")
 						client.thirdPartyConnections.registerDeviceWithThirdParty(registration: rego, completion: completion)
 					}
-					EndpointLink<VoidReply>("Deregister Device") { client, completion in
+					EndpointLink<Zone5.VoidReply>("Deregister Device") { client, completion in
 						client.thirdPartyConnections.deregisterDeviceWithThirdParty(token: "1234", completion: completion)
 					}
 					EndpointLink<UpgradeAvailableResponse>("Is upgrade available") { client, completion in

--- a/Zone5/Transport/Request.swift
+++ b/Zone5/Transport/Request.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public struct Request {
 
-	var endpoint: RequestEndpoint
+	public var endpoint: RequestEndpoint
 
 	var method: Method
 

--- a/Zone5/Transport/Request.swift
+++ b/Zone5/Transport/Request.swift
@@ -81,7 +81,7 @@ public struct Request {
 				throw Zone5.Error.unexpectedRequestBody
 			}
 
-		case .post, .delete:
+        default:
 			// body is optional
 			if let body = body {
 				do {
@@ -93,9 +93,6 @@ public struct Request {
 					throw Zone5.Error.failedEncodingRequestBody
 				}
 			}
-
-		default:
-			throw Zone5.Error.unknown
 		}
 		
 		return request

--- a/Zone5/Transport/URLRequestInterceptor.swift
+++ b/Zone5/Transport/URLRequestInterceptor.swift
@@ -88,7 +88,9 @@ internal class URLRequestInterceptor: URLProtocol {
 	private func decorateAndSendRequest() {
 		// decorate headers. This needs to be after the refresh code as the token may change
 		let request = URLRequestInterceptor.decorate(request: self.request)
+        #if DEBUG
         print("Decorated for \(request.url?.absoluteString ?? ""): \(request.allHTTPHeaderFields ?? [:])")
+        #endif
 		// send
 		sendRequest(request)
 	}

--- a/Zone5/Transport/URLRequestInterceptor.swift
+++ b/Zone5/Transport/URLRequestInterceptor.swift
@@ -88,6 +88,7 @@ internal class URLRequestInterceptor: URLProtocol {
 	private func decorateAndSendRequest() {
 		// decorate headers. This needs to be after the refresh code as the token may change
 		let request = URLRequestInterceptor.decorate(request: self.request)
+        print("Decorated for \(request.url?.absoluteString ?? ""): \(request.allHTTPHeaderFields ?? [:])")
 		// send
 		sendRequest(request)
 	}

--- a/Zone5/Transport/VoidReply.swift
+++ b/Zone5/Transport/VoidReply.swift
@@ -8,4 +8,6 @@
 
 import Foundation
 
-public struct VoidReply: Decodable {}
+public extension Zone5 {
+    struct VoidReply: Decodable {}
+}

--- a/Zone5/Views/ThirdPartyConnectionsView.swift
+++ b/Zone5/Views/ThirdPartyConnectionsView.swift
@@ -36,7 +36,7 @@ public class ThirdPartyConnectionsView: APIView {
 	/// - Parameters:
 	/// - token: 3rd party push token to deregister
 	@discardableResult
-	public func deregisterDeviceWithThirdParty(token: String, completion: @escaping Zone5.ResultHandler<VoidReply>) -> PendingRequest? {
+	public func deregisterDeviceWithThirdParty(token: String, completion: @escaping Zone5.ResultHandler<Zone5.VoidReply>) -> PendingRequest? {
 		let endpoint = Endpoints.deregisterDeviceWithThirdParty.replacingTokens(["token": token])
 		return delete(endpoint, with: completion)
 	}

--- a/Zone5/Views/UsersView.swift
+++ b/Zone5/Views/UsersView.swift
@@ -44,7 +44,7 @@ public class UsersView: APIView {
 	
 	/// Delete a user account
 	@discardableResult
-	public func deleteAccount(userID: Int, completion: @escaping Zone5.ResultHandler<VoidReply>) -> PendingRequest? {
+	public func deleteAccount(userID: Int, completion: @escaping Zone5.ResultHandler<Zone5.VoidReply>) -> PendingRequest? {
 		let endpoint = Endpoints.deleteUser.replacingTokens(["userID": userID])
 		return get(endpoint, with: completion)
 	}
@@ -68,7 +68,6 @@ public class UsersView: APIView {
 			completion(.failure(.invalidConfiguration))
 			return
 		}
-        
 		_ = post(Endpoints.login, body: body, expectedType: LoginResponse.self) { [weak self] result in
 		defer { completion(result) }
 
@@ -112,7 +111,7 @@ public class UsersView: APIView {
 	}
 	
 	/// Change a user's password - oldPassword is only required in Specialized environment
-	public func changePassword(oldPassword: String?, newPassword: String, completion: @escaping Zone5.ResultHandler<VoidReply>) {
+	public func changePassword(oldPassword: String?, newPassword: String, completion: @escaping Zone5.ResultHandler<Zone5.VoidReply>) {
 		guard let zone5 = zone5 else {
 			completion(.failure(.invalidConfiguration))
 			return
@@ -129,7 +128,7 @@ public class UsersView: APIView {
 					completion(.failure(error))
 				case .success(let result):
 					if result {
-						completion(.success(VoidReply()))
+						completion(.success(Zone5.VoidReply()))
 					} else {
 						completion(.failure(Zone5.Error.unknown))
 					}

--- a/Zone5/Zone5.swift
+++ b/Zone5/Zone5.swift
@@ -8,7 +8,7 @@ final public class Zone5 {
 	public static let shared = Zone5()
 
 	/// A light wrapper of the URLSession API, which enables communication with the server endpoints.
-	internal let httpClient: Zone5HTTPClient
+	public let httpClient: Zone5HTTPClient
 
 	internal static let specializedServer: String = "api-sp.todaysplan.com.au"
 	internal static let specializedStagingServer: String = "api-sp-staging.todaysplan.com.au"
@@ -261,7 +261,5 @@ final public class Zone5 {
 			case .transportFailure(let underlyingError): return ".transportFailure(underlyingError: \(underlyingError.localizedDescription))"
 			}
 		}
-
 	}
-
 }

--- a/Zone5Tests/Views/ThirdPartyViewTests.swift
+++ b/Zone5Tests/Views/ThirdPartyViewTests.swift
@@ -243,7 +243,7 @@ class ThirdPartyViewTests: XCTestCase {
 	}
 	
 	func testDeregisterDeviceWithThirdParty() {
-		let tests: [(token: AccessToken?, json: String, expectedResult: Result<VoidReply, Zone5.Error>)] = [
+		let tests: [(token: AccessToken?, json: String, expectedResult: Result<Zone5.VoidReply, Zone5.Error>)] = [
 			(
 				token: nil,
 				json: "{}",
@@ -253,7 +253,7 @@ class ThirdPartyViewTests: XCTestCase {
 				token: OAuthToken(rawValue: UUID().uuidString),
 				json: "{}",
 				expectedResult: .success {
-					return VoidReply()
+					return Zone5.VoidReply()
 				}
 			),
 		]

--- a/Zone5Tests/Views/UsersViewTests.swift
+++ b/Zone5Tests/Views/UsersViewTests.swift
@@ -232,7 +232,7 @@ class UsersViewTests: XCTestCase {
 	}
 	
 	func testDelete() {
-		let tests: [(token: AccessToken?, host: String, clientId: String?, secret: String?, json: String, expectedResult: Result<VoidReply, Zone5.Error>)] = [
+		let tests: [(token: AccessToken?, host: String, clientId: String?, secret: String?, json: String, expectedResult: Result<Zone5.VoidReply, Zone5.Error>)] = [
 			(
 				// delete requires a token, so this will fail authentication
 				token: nil,
@@ -259,7 +259,7 @@ class UsersViewTests: XCTestCase {
 				secret: nil,
 				json: "",
 				expectedResult: .success {
-					return VoidReply()
+					return Zone5.VoidReply()
 				}
 			)
 		]
@@ -487,7 +487,7 @@ class UsersViewTests: XCTestCase {
 	}
 	
 	func testChangePassword() {
-		let tests: [(token: AccessToken?, host: String, clientId: String?, secret: String?, json: String, expectedResult: Result<VoidReply, Zone5.Error>)] = [
+		let tests: [(token: AccessToken?, host: String, clientId: String?, secret: String?, json: String, expectedResult: Result<Zone5.VoidReply, Zone5.Error>)] = [
 			(
 				// changepassword requires a token, so this will fail authentication
 				token: nil,
@@ -505,7 +505,7 @@ class UsersViewTests: XCTestCase {
 				secret: nil,
 				json: "true",
 				expectedResult: .success {
-					return VoidReply()
+					return Zone5.VoidReply()
 				}
 			),
 			(
@@ -545,7 +545,7 @@ class UsersViewTests: XCTestCase {
 	}
 	
 	func testChangePasswordSpecialized() {
-		let tests: [(token: AccessToken?, host: String, clientId: String?, secret: String?, json: String, expectedResult: Result<VoidReply, Zone5.Error>)] = [
+		let tests: [(token: AccessToken?, host: String, clientId: String?, secret: String?, json: String, expectedResult: Result<Zone5.VoidReply, Zone5.Error>)] = [
 			(
 				// changepassword requires a token, so this will fail authentication
 				token: nil,
@@ -563,7 +563,7 @@ class UsersViewTests: XCTestCase {
 				secret: nil,
 				json: "",
 				expectedResult: .success {
-					return VoidReply()
+					return Zone5.VoidReply()
 				}
 			),
 			(


### PR DESCRIPTION
- Header injection per request
- Prevent adding base url to previous complete urls
- Additional logging for decorate function
- Make `VoidReply` public to prevent decoding issues
- Make `httpClient` public so there is only one reference (prevent `Zone5 = nil` error)