### PR TITLE
SI-32

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,4 +12,4 @@ jobs:
     - name: Build
       run: swift build -v
     - name: Run tests
-      run: swift test -v
+      run: swift test -v --parallel --num-workers 1 --enable-code-coverage

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,4 +12,4 @@ jobs:
     - name: Build
       run: swift build -v
     - name: Run tests
-      run: swift test -v --parallel --num-workers 1 --enable-code-coverage
+      run: swift test -v --parallel --num-workers 1

--- a/Example/ContentView.swift
+++ b/Example/ContentView.swift
@@ -281,7 +281,7 @@ struct ContentView: View {
 						var context = DataFileUploadContext()
 						context.equipment = .gravel
 						context.name = "Epic Ride"
-						//context.bikeID = "eaa6a925-9e6e-4121-ab35-d04381f51ff4"
+						//context.bikeID = bikeIDJean1Staging
 
 						client.activities.upload(fileURL, context: context) { result in
 							switch result {

--- a/Example/ContentView.swift
+++ b/Example/ContentView.swift
@@ -88,7 +88,7 @@ struct ContentView: View {
 								}
 							}
 						} else {
-							completion(.failure(.requiresAccessToken))
+							completion(.failure(.invalidConfiguration))
 						}
 					}
 					EndpointLink<Bool>("Set User Preferences") { client, completion in
@@ -97,7 +97,7 @@ struct ContentView: View {
 							prefs.metric = self.metric
 							client.users.setPreferences(preferences: prefs, completion: completion)
 						} else {
-							completion(.failure(.requiresAccessToken))
+							completion(.failure(.invalidConfiguration))
 						}
 					}
 					EndpointLink<Bool>("Check User Exists") { client, completion in
@@ -162,7 +162,7 @@ struct ContentView: View {
 						}
 					}
 				}
-				Section(header: Text("Auth"), footer: Text("Note that Register New User with Cognito makes an immediately usable user but with Gigya it requires a second auth step of going to the email for the user and clicking confirm email")) {
+				Section(header: Text("Auth"), footer: Text("Note that Register New User may requires a second auth step of going to the email for the user and clicking confirm email - depends on Cognito Client Key configuration")) {
 					EndpointLink<Bool>("Reset Password") { client, completion in
 						client.users.resetPassword(email: keyValueStore.userEmail, completion: completion)
 					}

--- a/Zone5/Transport/URLRequestInterceptor.swift
+++ b/Zone5/Transport/URLRequestInterceptor.swift
@@ -207,7 +207,9 @@ internal class URLRequestInterceptor: URLProtocol {
 		currentTask?.resume()
 	}
 	
-	/// Decode the Cognito token to get the username out of it. It is required (for some reason) for the cognito refresh
+	/// Decode the Cognito token to get the username out of it. It is required for the cognito refresh
+	/// note: We are now saving the username with the OAuthToken so we don't need to pull it out of
+	/// the cognito token. But if for some reason it is missing in the OAuthToken then we can try here
 	internal func extractUsername(from jwt: String) -> String? {
 		
 		enum DecodeErrors: Error {

--- a/Zone5/Transport/Zone5HTTPClient.swift
+++ b/Zone5/Transport/Zone5HTTPClient.swift
@@ -250,6 +250,7 @@ final public class Zone5HTTPClient {
 					} else {
 						// supposed to be success but can't find file
 						self?.complete(completion, with: .failure(.unknown))
+						return
 					}
 				} else if let resources = try? cacheURL.resourceValues(forKeys:[.fileSizeKey]), resources.fileSize! > 0, let data = try? Data(contentsOf: cacheURL) {
 					// server error case - the file is an error description
@@ -259,10 +260,8 @@ final public class Zone5HTTPClient {
 					// error case - no file to decode - use default error for statusCode
 					let message = Zone5.Error.ServerMessage(message: HTTPURLResponse.localizedString(forStatusCode: response.statusCode), statusCode: response.statusCode)
 					self?.complete(completion, with: .failure(.serverError(message)))
+					return
 				}
-				
-				// if we make it to here, something went wrong
-				self?.complete(completion, with: .failure(.unknown))
 			}
 			
 			task.resume()

--- a/Zone5/Views/UsersView.swift
+++ b/Zone5/Views/UsersView.swift
@@ -161,7 +161,6 @@ public class UsersView: APIView {
 			
 			if let zone5 = self?.zone5, case .success(let token) = result {
 				// if we successfully refreshed, update the token
-				//zone5.accessToken = AccessToken(rawValue: token.token)
 				zone5.accessToken = token
 			}
 		}

--- a/Zone5/Zone5.swift
+++ b/Zone5/Zone5.swift
@@ -271,7 +271,7 @@ final public class Zone5 {
 			case .unknown: return ".unknown"
 			case .invalidParameters: return ".invalidParameters"
 			case .invalidConfiguration: return ".invalidConfiguration"
-			case .serverError(let serverMessage): return ".serverError(message: \(serverMessage.message))"
+			case .serverError(let serverMessage): return ".serverError(statusCode: \(serverMessage.statusCode ?? 0), message: \(serverMessage.message))"
 			case .unexpectedRequestBody: return ".unexpectedRequestBody"
 			case .missingRequestBody: return ".missingRequestBody"
 			case .failedEncodingRequestBody: return ".failedEncodingParameters"

--- a/Zone5/Zone5.swift
+++ b/Zone5/Zone5.swift
@@ -206,10 +206,6 @@ final public class Zone5 {
 		/// with your client details, which are included in calls to the Zone5 API.
 		case invalidConfiguration
 
-		/// The method called requires a user's access token for authorization, you will need to use one of the
-		/// provided methods of authentication to retrieve one, or provide a previously gathered token.
-		case requiresAccessToken
-
 		/// A request body was provided to a request that doesn't take a request body.
 		///
 		/// Typically this means that the request itself is a HTTP GET request, whereas the request body suggests that
@@ -275,7 +271,6 @@ final public class Zone5 {
 			case .unknown: return ".unknown"
 			case .invalidParameters: return ".invalidParameters"
 			case .invalidConfiguration: return ".invalidConfiguration"
-			case .requiresAccessToken: return ".requiresAccessToken"
 			case .serverError(let serverMessage): return ".serverError(message: \(serverMessage.message))"
 			case .unexpectedRequestBody: return ".unexpectedRequestBody"
 			case .missingRequestBody: return ".missingRequestBody"

--- a/Zone5Tests/Transport/HTTPClientDownloadRequestTests.swift
+++ b/Zone5Tests/Transport/HTTPClientDownloadRequestTests.swift
@@ -48,7 +48,7 @@ final class Zone5HTTPClientDownloadRequestTests: XCTestCase {
 				
 				_ = httpClient.download(request) { result in
 					if case .failure(let error) = result, case .serverError(let message) = error, message.statusCode == 401 {
-							return // Success!
+						return // Success!
 					}
 
 					XCTFail("\(method.rawValue) request unexpectedly completed with \(result).")

--- a/Zone5Tests/Transport/HTTPClientDownloadRequestTests.swift
+++ b/Zone5Tests/Transport/HTTPClientDownloadRequestTests.swift
@@ -6,32 +6,29 @@ final class Zone5HTTPClientDownloadRequestTests: XCTestCase {
 	private let developmentAssets = Bundle.tests.urlsForDevelopmentAssets()!.filter { $0.pathExtension != "multipart" }
 
 	func testInvalidConfiguration() {
+		// explicitly set baseURL to nil. This will cause the request to fail early with invalid configuration
+		// the request should never be executed
 		var configuration = ConfigurationForTesting()
 		configuration.baseURL = nil
-		configuration.clientID = nil
-		configuration.clientSecret = nil
 
-		let methods: [Zone5.Method] = [
-			.get,
-			.post,
-		]
+		for method: Zone5.Method in [.get, .post] {
+			execute(configuration: configuration) { zone5, httpClient, urlSession in
+				let request = Request(endpoint: EndpointsForTesting.requiresAccessToken, method: method)
 
-		execute(with: methods, configuration: configuration) { zone5, httpClient, urlSession, method in
-			let request = Request(endpoint: EndpointsForTesting.requiresAccessToken, method: method)
+				urlSession.downloadTaskHandler = { urlRequest in
+					XCTFail("Request should never be performed when invalidly configured.")
 
-			urlSession.downloadTaskHandler = { urlRequest in
-				XCTFail("Request should never be performed when invalidly configured.")
-
-				return .error(Zone5.Error.unknown)
-			}
-
-			_ = httpClient.download(request) { result in
-				if case .failure(let error) = result,
-					case .invalidConfiguration = error {
-						return // Success!
+					return .error(Zone5.Error.unknown)
 				}
 
-				XCTFail("\(method.rawValue) request unexpectedly completed with \(result).")
+				_ = httpClient.download(request) { result in
+					if case .failure(let error) = result,
+						case .invalidConfiguration = error {
+							return // Success!
+					}
+
+					XCTFail("\(method.rawValue) request unexpectedly completed with \(result).")
+				}
 			}
 		}
 	}
@@ -40,27 +37,22 @@ final class Zone5HTTPClientDownloadRequestTests: XCTestCase {
 		var configuration = ConfigurationForTesting()
 		configuration.accessToken = nil
 
-		let methods: [Zone5.Method] = [
-			.get,
-			.post,
-		]
+		for method: Zone5.Method in [.get, .post] {
+			execute(configuration: configuration) { zone5, httpClient, urlSession in
+				let request = Request(endpoint: EndpointsForTesting.requiresAccessToken, method: method)
 
-		execute(with: methods, configuration: configuration) { zone5, httpClient, urlSession, method in
-			let request = Request(endpoint: EndpointsForTesting.requiresAccessToken, method: method)
-
-			urlSession.downloadTaskHandler = { urlRequest in
-				XCTFail("Request should never be performed when missing a required access token.")
-
-				return .error(Zone5.Error.unknown)
-			}
-
-			_ = httpClient.download(request) { result in
-				if case .failure(let error) = result,
-					case .requiresAccessToken = error {
-						return // Success!
+				urlSession.downloadTaskHandler = { urlRequest in
+					XCTAssertNil(urlRequest.allHTTPHeaderFields?["Authorization"])
+					return .failure("Unauthorized", statusCode: 401)
 				}
+				
+				_ = httpClient.download(request) { result in
+					if case .failure(let error) = result, case .serverError(let message) = error, message.statusCode == 401 {
+							return // Success!
+					}
 
-				XCTFail("\(method.rawValue) request unexpectedly completed with \(result).")
+					XCTFail("\(method.rawValue) request unexpectedly completed with \(result).")
+				}
 			}
 		}
 	}

--- a/Zone5Tests/Views/MetricsViewTests.swift
+++ b/Zone5Tests/Views/MetricsViewTests.swift
@@ -15,8 +15,8 @@ class MetricsViewTests: XCTestCase {
 		let tests: [(token: AccessToken?, json: String, expectedResult: Result<MappedResult<UserWorkoutResult>, Zone5.Error>)] = [
 			(
 				token: nil,
-				json: "{}",
-				expectedResult: .failure(.requiresAccessToken)
+				json: "n/a",
+				expectedResult: .failure(authFailure)
 			),
 			(
 				token: OAuthToken(rawValue: UUID().uuidString),
@@ -50,12 +50,6 @@ class MetricsViewTests: XCTestCase {
 		]
 
 		execute(with: tests) { client, _, urlSession, test in
-			client.accessToken = test.token
-
-			urlSession.dataTaskHandler = { request in
-				XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer \(test.token?.rawValue ?? "UNKNOWN")")
-				return .success(test.json)
-			}
 
 			client.metrics.getBikeMetrics(ranges: [], fields: ["fields"], bikeUids: ["d584c5cb-e81f-4fbe-bc0d-667e9bcd2c4c"]) { result in
 				switch (result, test.expectedResult) {
@@ -80,5 +74,4 @@ class MetricsViewTests: XCTestCase {
 			}
 		}
 	}
-
 }

--- a/Zone5Tests/Views/OAuthViewTests.swift
+++ b/Zone5Tests/Views/OAuthViewTests.swift
@@ -67,10 +67,13 @@ class OAuthViewTests: XCTestCase {
 	}
 	
 	func testAdhocToken() {
-		var expected = OAuthToken(token: "test token", expiresIn: 123)
-		expected.scope = "things"
+		var expectedAuthToken = OAuthToken(token: "test token", expiresIn: 123)
+		expectedAuthToken.scope = "things"
 		
-		let tests = [expected]
+		let tests: [(token: OAuthToken?, json: String, expectedResult: Zone5.Result<OAuthToken>)] = [
+			(token:expectedAuthToken, json:"{\"access_token\": \"test token\", \"scope\": \"things\", \"expires_in\":123}", expectedResult:.success(expectedAuthToken))
+		]
+		
 		execute(with: tests) { client, _, urlSession, expected in
 			
 			urlSession.dataTaskHandler = { request in
@@ -83,9 +86,9 @@ class OAuthViewTests: XCTestCase {
 			client.oAuth.accessToken(username: "username", password: "password") { result in
 				switch result {
 				case .success(let token):
-					XCTAssertEqual(token.accessToken, expected.accessToken)
-					XCTAssertEqual(token.expiresIn, expected.expiresIn)
-					XCTAssertEqual(token.scope, expected.scope)
+					XCTAssertEqual(token.accessToken, expectedAuthToken.accessToken)
+					XCTAssertEqual(token.expiresIn, expectedAuthToken.expiresIn)
+					XCTAssertEqual(token.scope, expectedAuthToken.scope)
 					
 				default:
 					XCTFail()

--- a/Zone5Tests/Views/ThirdPartyViewTests.swift
+++ b/Zone5Tests/Views/ThirdPartyViewTests.swift
@@ -19,7 +19,7 @@ class ThirdPartyViewTests: XCTestCase {
 			(
 				token: nil,
 				json: "{\"success\":true}",
-				expectedResult: .failure(.requiresAccessToken)
+				expectedResult: .failure(authFailure)
 			),
 			(
 				token: OAuthToken(rawValue: UUID().uuidString),
@@ -44,13 +44,6 @@ class ThirdPartyViewTests: XCTestCase {
 		]
 
 		execute(with: tests) { client, _, urlSession, test in
-			client.accessToken = test.token
-
-			urlSession.dataTaskHandler = { request in
-				XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer \(test.token?.rawValue ?? "UNKNOWN")")
-				return .success(test.json)
-			}
-
 			let _ = client.thirdPartyConnections.setThirdPartyToken(type: UserConnectionsType.strava, connection: token1) { result in
 				switch (result, test.expectedResult) {
 				case (.failure(let lhs), .failure(let rhs)):
@@ -74,7 +67,7 @@ class ThirdPartyViewTests: XCTestCase {
 				// this endpoint requires auth
 				token: nil,
 				json: "{\"available\":false}",
-				expectedResult: .failure(.requiresAccessToken)
+				expectedResult: .failure(authFailure)
 			),
 			(
 				// successful request, result is false
@@ -109,12 +102,6 @@ class ThirdPartyViewTests: XCTestCase {
 		]
 
 		execute(with: tests) { client, _, urlSession, test in
-			client.accessToken = test.token
-
-			urlSession.dataTaskHandler = { request in
-				XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer \(test.token?.rawValue ?? "UNKNOWN")")
-				return .success(test.json)
-			}
 
 			let _ = client.thirdPartyConnections.hasThirdPartyToken(type: UserConnectionsType.strava) { result in
 				switch (result, test.expectedResult) {
@@ -144,7 +131,7 @@ class ThirdPartyViewTests: XCTestCase {
 				// endpoint requires auth
 				token: nil,
 				json: "{\"success\":true}",
-				expectedResult: .failure(.requiresAccessToken)
+				expectedResult: .failure(authFailure)
 			),
 			(
 				// successful response, with false result
@@ -167,13 +154,6 @@ class ThirdPartyViewTests: XCTestCase {
 		]
 
 		execute(with: tests) { client, _, urlSession, test in
-			client.accessToken = test.token
-
-			urlSession.dataTaskHandler = { request in
-				XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer \(test.token?.rawValue ?? "UNKNOWN")")
-				return .success(test.json)
-			}
-
 			let _ = client.thirdPartyConnections.removeThirdPartyToken(type: UserConnectionsType.strava) { result in
 				switch (result, test.expectedResult) {
 				case (.failure(let lhs), .failure(let rhs)):
@@ -199,7 +179,7 @@ class ThirdPartyViewTests: XCTestCase {
 				// endpoint requires auth
 				token: nil,
 				json: "{\"token\": 12345}",
-				expectedResult: .failure(.requiresAccessToken)
+				expectedResult: .failure(authFailure)
 			),
 			(
 				// success
@@ -218,13 +198,6 @@ class ThirdPartyViewTests: XCTestCase {
 		]
 
 		execute(with: tests) { client, _, urlSession, test in
-			client.accessToken = test.token
-
-			urlSession.dataTaskHandler = { request in
-				XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer \(test.token?.rawValue ?? "UNKNOWN")")
-				return .success(test.json)
-			}
-
 			let _ = client.thirdPartyConnections.registerDeviceWithThirdParty(registration: pushRegistration1) { result in
 				switch (result, test.expectedResult) {
 				case (.failure(let lhs), .failure(let rhs)):
@@ -247,7 +220,7 @@ class ThirdPartyViewTests: XCTestCase {
 			(
 				token: nil,
 				json: "{}",
-				expectedResult: .failure(.requiresAccessToken)
+				expectedResult: .failure(authFailure)
 			),
 			(
 				token: OAuthToken(rawValue: UUID().uuidString),
@@ -259,13 +232,7 @@ class ThirdPartyViewTests: XCTestCase {
 		]
 
 		execute(with: tests) { client, _, urlSession, test in
-			client.accessToken = test.token
-
-			urlSession.dataTaskHandler = { request in
-				XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer \(test.token?.rawValue ?? "UNKNOWN")")
-				return .success(test.json)
-			}
-
+			
 			let _ = client.thirdPartyConnections.deregisterDeviceWithThirdParty(token: "12345") { result in
 				switch (result, test.expectedResult) {
 				case (.failure(let lhs), .failure(let rhs)):
@@ -289,7 +256,7 @@ class ThirdPartyViewTests: XCTestCase {
 			(
 				token: nil,
 				json: "{}",
-				expectedResult: .failure(.requiresAccessToken)
+				expectedResult: .failure(authFailure)
 			),
 			(
 				token: OAuthToken(rawValue: UUID().uuidString),
@@ -301,12 +268,6 @@ class ThirdPartyViewTests: XCTestCase {
 		]
 
 		execute(with: tests) { client, _, urlSession, test in
-			client.accessToken = test.token
-
-			urlSession.dataTaskHandler = { request in
-				XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer \(test.token?.rawValue ?? "UNKNOWN")")
-				return .success(test.json)
-			}
 
 			let _ = client.userAgents.getDeprecated() { result in
 				switch (result, test.expectedResult) {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,8 +12,9 @@ sonar.tests=Zone5Tests
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
 
-#sonar.swift.appScheme=Zone5
-#sonar.swift.simulator=platform=iOS Simulator,name=iPhone 11,OS=latest
+sonar.swift.appScheme=Zone5
+sonar.swift.simulator=platform=iOS Simulator,name=iPhone 11,OS=latest
+#sonar.swift.coverage.reportPath=
 
 sonar.c.file.suffixes=-
 sonar.cpp.file.suffixes=-


### PR DESCRIPTION
* Don't handle no token error on the client side. Let it go all the way to the server and let the server respond with a 401.