### PR TITLE
SI-41 Limiting Concurrent Requests

### DIFF
--- a/Zone5.xcodeproj/project.pbxproj
+++ b/Zone5.xcodeproj/project.pbxproj
@@ -658,6 +658,7 @@
 			isa = PBXGroup;
 			children = (
 				A167D6D023838F0000507276 /* HTTPClientPerformRequestTests.swift */,
+				A167D6D42383DBAB00507276 /* HTTPClientUploadRequestTests.swift */,
 				A1C42B6523850CF2004E33B9 /* HTTPClientDownloadRequestTests.swift */,
 				A196032D2379445200CEB121 /* RequestTests.swift */,
 				A1713CBB2386060F0084BDDC /* RequestEndpointTests.swift */,
@@ -665,7 +666,6 @@
 				A1EBDAD8237A21DD00834B21 /* MultipartEncodedBodyTests.swift */,
 				0F7C8E59256C9743005CF025 /* URLRequestInterceptorTests.swift */,
 				0F1C9F8625898C89000C12FD /* ResponseDecodingTests.swift */,
-				A167D6D42383DBAB00507276 /* HTTPClientUploadRequestTests.swift */,
 			);
 			path = Transport;
 			sourceTree = "<group>";

--- a/Zone5.xcodeproj/project.pbxproj
+++ b/Zone5.xcodeproj/project.pbxproj
@@ -92,7 +92,7 @@
 		A182D1CD2372AB0F00112501 /* URLEncodedBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = A182D1B72372AB0E00112501 /* URLEncodedBody.swift */; };
 		A182D1CE2372AB0F00112501 /* JSONEncodedBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = A182D1B82372AB0E00112501 /* JSONEncodedBody.swift */; };
 		A182D1CF2372AB0F00112501 /* RequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = A182D1B92372AB0E00112501 /* RequestBody.swift */; };
-		A182D1D02372AB0F00112501 /* Zone5HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A182D1BA2372AB0E00112501 /* Zone5HTTPClient.swift */; };
+		A182D1D02372AB0F00112501 /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A182D1BA2372AB0E00112501 /* HTTPClient.swift */; };
 		A182D1D12372AB0F00112501 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = A182D1BB2372AB0E00112501 /* Request.swift */; };
 		A182D1D32372AB0F00112501 /* ActivitiesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A182D1BE2372AB0F00112501 /* ActivitiesView.swift */; };
 		A182D1D42372AB0F00112501 /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A182D1BF2372AB0F00112501 /* View.swift */; };
@@ -285,7 +285,7 @@
 		A182D1B72372AB0E00112501 /* URLEncodedBody.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLEncodedBody.swift; sourceTree = "<group>"; };
 		A182D1B82372AB0E00112501 /* JSONEncodedBody.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONEncodedBody.swift; sourceTree = "<group>"; };
 		A182D1B92372AB0E00112501 /* RequestBody.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestBody.swift; sourceTree = "<group>"; };
-		A182D1BA2372AB0E00112501 /* Zone5HTTPClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Zone5HTTPClient.swift; sourceTree = "<group>"; };
+		A182D1BA2372AB0E00112501 /* HTTPClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
 		A182D1BB2372AB0E00112501 /* Request.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
 		A182D1BE2372AB0F00112501 /* ActivitiesView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivitiesView.swift; sourceTree = "<group>"; };
 		A182D1BF2372AB0F00112501 /* View.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
@@ -492,7 +492,7 @@
 		A182D1B52372AB0E00112501 /* Transport */ = {
 			isa = PBXGroup;
 			children = (
-				A182D1BA2372AB0E00112501 /* Zone5HTTPClient.swift */,
+				A182D1BA2372AB0E00112501 /* HTTPClient.swift */,
 				A182D1C52372AB0F00112501 /* AccessToken.swift */,
 				A182D1B62372AB0E00112501 /* RequestEndpoint.swift */,
 				A182D1B92372AB0E00112501 /* RequestBody.swift */,
@@ -936,7 +936,7 @@
 				A196035923794DD200CEB121 /* UserWorkoutFailedReason.swift in Sources */,
 				0FB27F3D24060BFA00D7991B /* UserWorkoutResultBike.swift in Sources */,
 				0F4A88CA2564A1ED005C20A2 /* URLProtocolProperty.swift in Sources */,
-				A182D1D02372AB0F00112501 /* Zone5HTTPClient.swift in Sources */,
+				A182D1D02372AB0F00112501 /* HTTPClient.swift in Sources */,
 				0F7ED32825708B1200452C13 /* PaymentVerification.swift in Sources */,
 				0F7D4722253D4998005B21A9 /* PushRegistrationResponse.swift in Sources */,
 				0FAA7566240CA34300CB3C73 /* LoginRequest.swift in Sources */,

--- a/Zone5/Transport/HTTPClient.swift
+++ b/Zone5/Transport/HTTPClient.swift
@@ -79,9 +79,6 @@ final internal class HTTPClient {
 	/// A closure that receives the result of a request.
 	internal typealias CompletionHandler<T> = (_ result: Result<T, Zone5.Error>) -> Void
 
-	/// Concurrent queue used to call the completion handlers.
-	private static let completionHandlerQueue = DispatchQueue(label: "Zone5HttpClient.callback.queue", qos: .userInitiated, attributes: .concurrent)
-
 	/// Validates the SDK configuration, and then calls the given `block` closure, handling any thrown errors using the given `completion`.
 	/// - Parameters:
 	///   - completion: Closure called with errors that are thrown in the `block`.
@@ -103,9 +100,7 @@ final internal class HTTPClient {
 			/// Wrap the provided completion handler in a dispatch call.
 			/// Do this synchronously so that tasks performed afterwards (like deleting files) are handled correctly.
 			let dispatchedCompletion: CompletionHandler<T> = { result in
-				HTTPClient.completionHandlerQueue.sync {
-					completion(result)
-				}
+				completion(result)
 
 				operation.finish()
 			}
@@ -116,13 +111,11 @@ final internal class HTTPClient {
 			return operation
 		}
 		catch {
-			HTTPClient.completionHandlerQueue.sync {
-				if let error = error as? Zone5.Error {
-					completion(.failure(error))
-				}
-				else {
-					completion(.failure(.unknown))
-				}
+			if let error = error as? Zone5.Error {
+				completion(.failure(error))
+			}
+			else {
+				completion(.failure(.unknown))
 			}
 
 			return nil

--- a/Zone5/Transport/HTTPClient.swift
+++ b/Zone5/Transport/HTTPClient.swift
@@ -15,11 +15,7 @@ final internal class HTTPClient {
 		let configuration: URLSessionConfiguration = .default
 		configuration.protocolClasses = [ URLRequestInterceptor.self ]
 
-		let operationQueue = OperationQueue()
-		operationQueue.qualityOfService = .userInitiated // Default operation queues have a QoS of `.utility` which can result in poor performance.
-		operationQueue.maxConcurrentOperationCount = 1 // Operation queues for URLSessions must be serial.
-
-		self.init(urlSession: URLSession(configuration: configuration, delegate: nil, delegateQueue: operationQueue))
+		self.init(urlSession: URLSession(configuration: configuration, delegate: nil, delegateQueue: URLRequestDelegate.OperationQueue()))
 	}
 
 	/// Initializes a new instance of the `HTTPClient` with the given `URLSession`.

--- a/Zone5/Transport/URLRequestDelegate.swift
+++ b/Zone5/Transport/URLRequestDelegate.swift
@@ -14,8 +14,18 @@ final internal class URLRequestDelegate: NSObject, URLSessionDataDelegate, URLSe
 
 	let notificationCenter: NotificationCenter
 
+	let operationQueue: OperationQueue
+
 	init(notificationCenter: NotificationCenter = .default) {
 		self.notificationCenter = notificationCenter
+
+		// Default operation queues have a QoS of `.utility`. This can result in poor performance for user-initiated
+		// requests like ours. Increase the QoS to `.userInitiated`.
+		// Also the doco for `URLSession` states that the operation queue must be serial.
+		let operationQueue = OperationQueue()
+		operationQueue.qualityOfService = .userInitiated
+		operationQueue.maxConcurrentOperationCount = 1
+		self.operationQueue = operationQueue
 	}
 
 	// MARK: Notifications posted by this delegate

--- a/Zone5/Transport/URLRequestDelegate.swift
+++ b/Zone5/Transport/URLRequestDelegate.swift
@@ -14,18 +14,23 @@ final internal class URLRequestDelegate: NSObject, URLSessionDataDelegate, URLSe
 
 	let notificationCenter: NotificationCenter
 
-	let operationQueue: OperationQueue
-
 	init(notificationCenter: NotificationCenter = .default) {
 		self.notificationCenter = notificationCenter
+	}
 
-		// Default operation queues have a QoS of `.utility`. This can result in poor performance for user-initiated
-		// requests like ours. Increase the QoS to `.userInitiated`.
-		// Also the doco for `URLSession` states that the operation queue must be serial.
-		let operationQueue = OperationQueue()
-		operationQueue.qualityOfService = .userInitiated
-		operationQueue.maxConcurrentOperationCount = 1
-		self.operationQueue = operationQueue
+	// MARK: Delegate queue
+
+	/// Operation queue subclass that provides the defaults we like for our `URLSession` instances.
+	/// - Note: The delegate queue provided to a `URLSession` is used regardless of whether a custom delegate is
+	/// 	provided actually provided: completion handlers are called on the provided delegate queue.
+	final internal class OperationQueue: Foundation.OperationQueue {
+
+		override init() {
+			super.init()
+			qualityOfService = .userInitiated // Default operation queues have a QoS of `.utility` which can result in poor performance.
+			maxConcurrentOperationCount = 1 // Operation queues for URLSessions must be serial.
+		}
+
 	}
 
 	// MARK: Notifications posted by this delegate

--- a/Zone5/Transport/URLRequestInterceptor.swift
+++ b/Zone5/Transport/URLRequestInterceptor.swift
@@ -79,12 +79,9 @@ internal class URLRequestInterceptor: URLProtocol {
 
 	// MARK: Shared URL sessions
 
-	/// A shared delegate for handling events related to uploads and downloads.
-	private static let urlRequestDelegate = URLRequestDelegate()
-
 	/// URLSession used by the `URLRequestInterceptor` for standard API requests.
 	private static let sharedDataSession: URLSession = {
-		return URLSession(configuration: .default, delegate: nil, delegateQueue: urlRequestDelegate.operationQueue)
+		return URLSession(configuration: .default, delegate: nil, delegateQueue: URLRequestDelegate.OperationQueue())
 	}()
 
 	/// URLSession used by the `URLRequestInterceptor` for file downloads.
@@ -92,7 +89,7 @@ internal class URLRequestInterceptor: URLProtocol {
 	private static let sharedDownloadSession: URLSession = {
 		let configuration: URLSessionConfiguration = .default
 		configuration.httpMaximumConnectionsPerHost = 1
-		return URLSession(configuration: configuration, delegate: urlRequestDelegate, delegateQueue: urlRequestDelegate.operationQueue)
+		return URLSession(configuration: configuration, delegate: URLRequestDelegate(), delegateQueue: URLRequestDelegate.OperationQueue())
 	}()
 
 	/// URLSession used by the `URLRequestInterceptor` for file uploads.
@@ -102,7 +99,7 @@ internal class URLRequestInterceptor: URLProtocol {
 		configuration.httpMaximumConnectionsPerHost = 1
 		configuration.sessionSendsLaunchEvents = true
 		configuration.isDiscretionary = false
-		return URLSession(configuration: configuration, delegate: urlRequestDelegate, delegateQueue: urlRequestDelegate.operationQueue)
+		return URLSession(configuration: configuration, delegate: URLRequestDelegate(), delegateQueue: URLRequestDelegate.OperationQueue())
 	}()
 
 	// MARK: Handling intercepted requests

--- a/Zone5/Transport/URLRequestInterceptor.swift
+++ b/Zone5/Transport/URLRequestInterceptor.swift
@@ -232,7 +232,7 @@ internal class URLRequestInterceptor: URLProtocol {
 
 				if let location = notification.userInfo?["location"] as? URL, let filename = (response as? HTTPURLResponse)?.suggestedFilename {
 					// attempt to copy this file to another location because it will be deleted on return of this function
-					let cacheURL = Zone5HTTPClient.downloadsDirectory.appendingPathComponent(filename)
+					let cacheURL = HTTPClient.downloadsDirectory.appendingPathComponent(filename)
 					try? FileManager.default.removeItem(at: cacheURL)
 					try? FileManager.default.copyItem(at: location, to: cacheURL)
 				}

--- a/Zone5/Transport/Zone5HTTPClient.swift
+++ b/Zone5/Transport/Zone5HTTPClient.swift
@@ -209,7 +209,7 @@ final internal class Zone5HTTPClient {
 	) -> PendingRequest? {
 		return execute(on: Zone5HTTPClient.uploadQueue, with: completion) { zone5, completion in
 			var (urlRequest, multipartData) = try request.urlRequest(toUpload: fileURL, zone5: zone5)
-			let cacheURL = Zone5HTTPClient.uploadsDirectory.appendingPathComponent(fileURL.lastPathComponent).appendingPathExtension("multipart")
+			let cacheURL = Zone5HTTPClient.uploadsDirectory.appendingPathComponent("\(fileURL.lastPathComponent).\(UUID().uuidString).multipart")
 
 			// save URL against the request (needed to create actual uploadTask in interceptor)
 			urlRequest = urlRequest.setMeta(key: .fileURL, value: cacheURL)

--- a/Zone5/Transport/Zone5HTTPClient.swift
+++ b/Zone5/Transport/Zone5HTTPClient.swift
@@ -140,7 +140,7 @@ final internal class Zone5HTTPClient {
 		return execute(on: Zone5HTTPClient.dataQueue, with: completion) { zone5, completion in
 			let urlRequest = try request.urlRequest(zone5: zone5, taskType: .data)
 
-			return urlSession.dataTask(with: urlRequest) { data, response, error in
+			let task = urlSession.dataTask(with: urlRequest) { data, response, error in
 				if let error = error {
 					completion(.failure(.transportFailure(error)))
 				}
@@ -151,6 +151,9 @@ final internal class Zone5HTTPClient {
 					completion(.failure(.unknown))
 				}
 			}
+
+			task.priority = URLSessionTask.highPriority
+			return task
 		}
 	}
 
@@ -173,7 +176,7 @@ final internal class Zone5HTTPClient {
 			let decoder = self.decoder
             decoder.keyDecodingStrategy = keyDecodingStrategy
             
-			return urlSession.dataTask(with: urlRequest) { data, response, error in
+			let task = urlSession.dataTask(with: urlRequest) { data, response, error in
 				if let error = error {
 					completion(.failure(.transportFailure(error)))
 				}
@@ -184,6 +187,9 @@ final internal class Zone5HTTPClient {
 					completion(.failure(.unknown))
 				}
 			}
+
+			task.priority = URLSessionTask.highPriority
+			return task
 		}
 	}
     

--- a/Zone5/Zone5.swift
+++ b/Zone5/Zone5.swift
@@ -8,7 +8,7 @@ final public class Zone5 {
 	public static let shared = Zone5()
 
 	/// A light wrapper of the URLSession API, which enables communication with the server endpoints.
-	internal let httpClient: Zone5HTTPClient
+	internal let httpClient: HTTPClient
 
 	internal static let specializedServer: String = "api-sp.todaysplan.com.au"
 	internal static let specializedStagingServer: String = "api-sp-staging.todaysplan.com.au"
@@ -16,7 +16,7 @@ final public class Zone5 {
 	public static let authTokenChangedNotification = Notification.Name("authTokenChangedNotification")
 	public static let updatedTermsNotification = Notification.Name("updatedTermsNotification")
 	
-	init(httpClient: Zone5HTTPClient = .init()) {
+	init(httpClient: HTTPClient = .init()) {
 		self.httpClient = httpClient
 
 		httpClient.zone5 = self

--- a/Zone5Tests/Transport/HTTPClientDownloadRequestTests.swift
+++ b/Zone5Tests/Transport/HTTPClientDownloadRequestTests.swift
@@ -198,4 +198,41 @@ final class Zone5HTTPClientDownloadRequestTests: XCTestCase {
 		}
 	}
 
+	func testRateLimiting() {
+		let parameters = [Zone5.Method](repeating: .get, count: 100)
+
+		var tasksInProgress = 0
+		var expectations: [XCTestExpectation] = []
+		execute(with: parameters) { zone5, httpClient, urlSession, method in
+			let request = Request(endpoint: EndpointsForTesting.requiresAccessToken, method: method, body: nil)
+
+			let fileURL = developmentAssets.randomElement()!
+
+			urlSession.downloadTaskHandler = { urlRequest in
+				DispatchQueue.main.async {
+					tasksInProgress += 1
+					XCTAssertTrue(tasksInProgress <= Zone5HTTPClient.uploadQueue.maxConcurrentOperationCount)
+				}
+
+				usleep(.random(in: 1000...10000)) // Give the tasks a chance to back up
+
+				return .success(fileURL)
+			}
+
+			let expectation = XCTestExpectation()
+			expectations.append(expectation)
+
+			_ = httpClient.download(request) { result in
+				DispatchQueue.main.async {
+					tasksInProgress -= 1
+					XCTAssertTrue(tasksInProgress <= Zone5HTTPClient.uploadQueue.maxConcurrentOperationCount)
+				}
+
+				expectation.fulfill()
+			}
+		}
+
+		wait(for: expectations, timeout: 5)
+	}
+
 }

--- a/Zone5Tests/Transport/HTTPClientDownloadRequestTests.swift
+++ b/Zone5Tests/Transport/HTTPClientDownloadRequestTests.swift
@@ -211,7 +211,7 @@ final class Zone5HTTPClientDownloadRequestTests: XCTestCase {
 			urlSession.downloadTaskHandler = { urlRequest in
 				DispatchQueue.main.async {
 					tasksInProgress += 1
-					XCTAssertTrue(tasksInProgress <= Zone5HTTPClient.uploadQueue.maxConcurrentOperationCount)
+					XCTAssertTrue(tasksInProgress <= HTTPClient.uploadQueue.maxConcurrentOperationCount)
 				}
 
 				usleep(.random(in: 1000...10000)) // Give the tasks a chance to back up
@@ -225,7 +225,7 @@ final class Zone5HTTPClientDownloadRequestTests: XCTestCase {
 			_ = httpClient.download(request) { result in
 				DispatchQueue.main.async {
 					tasksInProgress -= 1
-					XCTAssertTrue(tasksInProgress <= Zone5HTTPClient.uploadQueue.maxConcurrentOperationCount)
+					XCTAssertTrue(tasksInProgress <= HTTPClient.uploadQueue.maxConcurrentOperationCount)
 				}
 
 				expectation.fulfill()

--- a/Zone5Tests/Transport/HTTPClientPerformRequestTests.swift
+++ b/Zone5Tests/Transport/HTTPClientPerformRequestTests.swift
@@ -212,7 +212,7 @@ final class Zone5HTTPClientPerformRequestTests: XCTestCase {
 			urlSession.dataTaskHandler = { urlRequest in
 				DispatchQueue.main.async {
 					tasksInProgress += 1
-					XCTAssertTrue(tasksInProgress <= Zone5HTTPClient.dataQueue.maxConcurrentOperationCount)
+					XCTAssertTrue(tasksInProgress <= HTTPClient.dataQueue.maxConcurrentOperationCount)
 				}
 
 				usleep(.random(in: 1000...10000)) // Give the tasks a chance to back up
@@ -226,7 +226,7 @@ final class Zone5HTTPClientPerformRequestTests: XCTestCase {
 			_ = httpClient.perform(request, expectedType: User.self) { result in
 				DispatchQueue.main.async {
 					tasksInProgress -= 1
-					XCTAssertTrue(tasksInProgress <= Zone5HTTPClient.dataQueue.maxConcurrentOperationCount)
+					XCTAssertTrue(tasksInProgress <= HTTPClient.dataQueue.maxConcurrentOperationCount)
 				}
 
 				expectation.fulfill()

--- a/Zone5Tests/Transport/HTTPClientUploadRequestTests.swift
+++ b/Zone5Tests/Transport/HTTPClientUploadRequestTests.swift
@@ -185,7 +185,7 @@ final class Zone5HTTPClientUploadRequestTests: XCTestCase {
 			(.post, SearchInputReport.forInstance(activityType: .workout, identifier: 12345)),
 		]
 
-        var expectations: [XCTestExpectation] = []
+		var expectations: [XCTestExpectation] = []
 		execute(with: parameters) { zone5, httpClient, urlSession, parameters in
 			let request = Request(endpoint: EndpointsForTesting.requiresAccessToken, method: parameters.method, body: parameters.body)
 
@@ -215,8 +215,8 @@ final class Zone5HTTPClientUploadRequestTests: XCTestCase {
 				return .success("{\"id\": 12345678, \"email\": \"jame.smith@example.com\", \"firstname\": \"Jane\", \"lastname\": \"Smith\"}")
 			}
 
-            let expectation = XCTestExpectation()
-            expectations.append(expectation)
+			let expectation = XCTestExpectation()
+			expectations.append(expectation)
 
 			_ = httpClient.upload(fileURL, with: request, expectedType: User.self) { result in
 				if case .success(let user) = result {
@@ -229,11 +229,48 @@ final class Zone5HTTPClientUploadRequestTests: XCTestCase {
 					XCTFail("\(parameters.method.rawValue) request unexpectedly completed with \(result).")
 				}
 
-                expectation.fulfill()
+				expectation.fulfill()
 			}
 		}
 
-        wait(for: expectations, timeout: 5)
+		wait(for: expectations, timeout: 5)
+	}
+
+	func testRateLimiting() {
+		let parameters = [Zone5.Method](repeating: .get, count: 100)
+
+		var tasksInProgress = 0
+		var expectations: [XCTestExpectation] = []
+		execute(with: parameters) { zone5, httpClient, urlSession, method in
+			let request = Request(endpoint: EndpointsForTesting.requiresAccessToken, method: method, body: nil)
+
+			let fileURL = developmentAssets.randomElement()!
+
+			urlSession.uploadTaskHandler = { urlRequest, uploadedURL in
+				DispatchQueue.main.async {
+					tasksInProgress += 1
+					XCTAssertTrue(tasksInProgress <= Zone5HTTPClient.downloadQueue.maxConcurrentOperationCount)
+				}
+
+				usleep(.random(in: 1000...10000)) // Give the tasks a chance to back up
+
+				return .success("{\"id\": 12345678, \"email\": \"jame.smith@example.com\", \"firstname\": \"Jane\", \"lastname\": \"Smith\"}")
+			}
+
+			let expectation = XCTestExpectation()
+			expectations.append(expectation)
+
+			_ = httpClient.upload(fileURL, with: request, expectedType: User.self) { result in
+				DispatchQueue.main.async {
+					tasksInProgress -= 1
+					XCTAssertTrue(tasksInProgress <= Zone5HTTPClient.downloadQueue.maxConcurrentOperationCount)
+				}
+
+				expectation.fulfill()
+			}
+		}
+
+		wait(for: expectations, timeout: 5)
 	}
 
 }

--- a/Zone5Tests/Transport/HTTPClientUploadRequestTests.swift
+++ b/Zone5Tests/Transport/HTTPClientUploadRequestTests.swift
@@ -249,7 +249,7 @@ final class Zone5HTTPClientUploadRequestTests: XCTestCase {
 			urlSession.uploadTaskHandler = { urlRequest, uploadedURL in
 				DispatchQueue.main.async {
 					tasksInProgress += 1
-					XCTAssertTrue(tasksInProgress <= Zone5HTTPClient.downloadQueue.maxConcurrentOperationCount)
+					XCTAssertTrue(tasksInProgress <= HTTPClient.downloadQueue.maxConcurrentOperationCount)
 				}
 
 				usleep(.random(in: 1000...10000)) // Give the tasks a chance to back up
@@ -263,7 +263,7 @@ final class Zone5HTTPClientUploadRequestTests: XCTestCase {
 			_ = httpClient.upload(fileURL, with: request, expectedType: User.self) { result in
 				DispatchQueue.main.async {
 					tasksInProgress -= 1
-					XCTAssertTrue(tasksInProgress <= Zone5HTTPClient.downloadQueue.maxConcurrentOperationCount)
+					XCTAssertTrue(tasksInProgress <= HTTPClient.downloadQueue.maxConcurrentOperationCount)
 				}
 
 				expectation.fulfill()

--- a/Zone5Tests/Utilities/TestHTTPClientURLSession.swift
+++ b/Zone5Tests/Utilities/TestHTTPClientURLSession.swift
@@ -146,7 +146,7 @@ class TestHTTPClientURLSession: HTTPClientURLSession {
 					"Content-Type": "application/json",
 				])!
 				
-				let tempURL = Zone5HTTPClient.downloadsDirectory.appendingPathComponent(response.suggestedFilename!)
+				let tempURL = HTTPClient.downloadsDirectory.appendingPathComponent(response.suggestedFilename!)
 				let json = "{\"message\": \"\(message)\"}"
 				try! json.write(to: tempURL, atomically: true, encoding: .utf8)
 
@@ -172,7 +172,7 @@ class TestHTTPClientURLSession: HTTPClientURLSession {
 					"Content-Type": "application/octet-stream",
 				])!
 				
-				let copy = Zone5HTTPClient.downloadsDirectory.appendingPathComponent(response.suggestedFilename!)
+				let copy = HTTPClient.downloadsDirectory.appendingPathComponent(response.suggestedFilename!)
 				try? FileManager.default.copyItem(at: url, to: copy)
 
 				completionHandler(url, response, nil)

--- a/Zone5Tests/Utilities/XCTestCase.swift
+++ b/Zone5Tests/Utilities/XCTestCase.swift
@@ -48,14 +48,14 @@ extension XCTestCase {
 	
 	func createNewZone5() -> Zone5 {
 		let urlSession = TestHTTPClientURLSession()
-		let httpClient = Zone5HTTPClient(urlSession: urlSession)
+		let httpClient = HTTPClient(urlSession: urlSession)
 		return Zone5(httpClient: httpClient)
 	}
 	
 
-	func execute(configuration: ConfigurationForTesting = .init(), _ tests: (_ zone5: Zone5, _ httpClient: Zone5HTTPClient, _ urlSession: TestHTTPClientURLSession) throws -> Void) rethrows {
+	func execute(configuration: ConfigurationForTesting = .init(), _ tests: (_ zone5: Zone5, _ httpClient: HTTPClient, _ urlSession: TestHTTPClientURLSession) throws -> Void) rethrows {
 		let urlSession = TestHTTPClientURLSession()
-		let httpClient = Zone5HTTPClient(urlSession: urlSession)
+		let httpClient = HTTPClient(urlSession: urlSession)
 		
 		let zone5 = Zone5(httpClient: httpClient)
 		zone5.configure(with: configuration)
@@ -65,7 +65,7 @@ extension XCTestCase {
 
 	typealias P<T:Decodable> = (token:AccessToken?, json:String, expectedResult:Zone5.Result<T>)
 
-	func execute<T>(with parameters: [P<T>], configuration: ConfigurationForTesting = .init(), _ tests: (_ zone5: Zone5, _ httpClient: Zone5HTTPClient, _ urlSession: TestHTTPClientURLSession, _ parameters: P<T>) throws -> Void) rethrows {
+	func execute<T>(with parameters: [P<T>], configuration: ConfigurationForTesting = .init(), _ tests: (_ zone5: Zone5, _ httpClient: HTTPClient, _ urlSession: TestHTTPClientURLSession, _ parameters: P<T>) throws -> Void) rethrows {
 		try parameters.forEach { parameter in
 			try execute(configuration: configuration) { zone5, httpClient, urlSession in
 				zone5.accessToken = parameter.token
@@ -94,7 +94,7 @@ extension XCTestCase {
 		}
 	}
 
-	func execute<T>(with parameters: [T], configuration: ConfigurationForTesting = .init(), _ tests: (_ zone5: Zone5, _ httpClient: Zone5HTTPClient, _ urlSession: TestHTTPClientURLSession, _ parameters: T) throws -> Void) rethrows {
+	func execute<T>(with parameters: [T], configuration: ConfigurationForTesting = .init(), _ tests: (_ zone5: Zone5, _ httpClient: HTTPClient, _ urlSession: TestHTTPClientURLSession, _ parameters: T) throws -> Void) rethrows {
 		try parameters.forEach { parameter in
 			try execute(configuration: configuration) { zone5, httpClient, urlSession in
 				try tests(zone5, httpClient, urlSession, parameter)


### PR DESCRIPTION
This PR routes requests through operation queues in order to set a ceiling on how many can be in-flight at any given moment (4 data requests, 1 upload request, and 1 download). This is partially to replicate the  behaviour of the `httpMaximumConnectionsPerHost` setting prior to the server moving to HTTP/2, and to reduce the overall bandwidth that can be consumed by file transfers.