### PR TITLE
Improvements to CI Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,9 @@
-name: Build
+name: Unit Tests
+
+# This workflow will run for pull requests that are opened or updated with new commits, as well as when
+# commits are pushed directly to the master or develop branches (including when pull requests are merged).
+#
+# The `build-and-test` job will run every time the workflow does.
 
 on:
   pull_request:
@@ -20,8 +25,66 @@ jobs:
       id: cache-derived-data
       uses: actions/cache@v2
       with:
-        path: "${GITHUB_WORKSPACE}/DerivedData"
+        path: |
+          "${GITHUB_WORKSPACE}/../DerivedDataSwift"
+          "${GITHUB_WORKSPACE}/../DerivedDataXcode"
         key: ${{ runner.os }}-derived-data
+
+    - name: Run Tests
+      run: |
+        DEVELOPER_PATH=$(xcode-select --print-path)
+        PLATFORM=$(ls -1 "${DEVELOPER_PATH}/Platforms/iPhoneOS.platform/DeviceSupport/" | sort -gr | head -n 1)
+        DEVICE=$(xcrun simctl list devices "iOS ${PLATFORM}" | grep "iPhone" | head -n 1 | sed -Ee 's/^.*\(([A-Z0-9\-]+)\).*$/\1/g')
+
+        xcodebuild test \
+          -workspace "Package.xcworkspace" \
+          -scheme "Zone5" \
+          -destination "platform=iOS Simulator,id=${DEVICE}" \
+          -enableCodeCoverage YES \
+          -derivedDataPath "${GITHUB_WORKSPACE}/../DerivedDataSwift" \
+          -resultBundlePath "SwiftPackage" \
+          CODE_SIGNING_REQUIRED=NO \
+          CODE_SIGN_IDENTITY=""
+
+        xcodebuild test \
+          -project "Zone5.xcodeproj" \
+          -scheme "Zone5" \
+          -destination "platform=iOS Simulator,id=${DEVICE}" \
+          -enableCodeCoverage YES \
+          -derivedDataPath "${GITHUB_WORKSPACE}/../DerivedDataXcode" \
+          -resultBundlePath "XcodeProject" \
+          CODE_SIGNING_REQUIRED=NO \
+          CODE_SIGN_IDENTITY=""
+
+    - name: Capture Results
+      if: success() || failure()
+      uses: kishikawakatsumi/xcresulttool@v1.3.1
+      with:
+        path: |
+          XcodeProject.xcresult
+          SwiftPackage.xcresult
+        show-passed-tests: false
+        show-code-coverage: false
+
+    - name: Merge Profile Data
+      run: |
+        PROFDATA_INPUT="${GITHUB_WORKSPACE}/../DerivedDataSwift/Build/ProfileData/*/*.profdata"
+        PROFDATA_OUTPUT="${GITHUB_WORKSPACE}/merged.profdata"
+        COVERAGE_OUTPUT="${GITHUB_WORKSPACE}/merged.lcov"
+        PRODUCTS_PATH="${GITHUB_WORKSPACE}/../DerivedDataSwift/Build/Products"
+
+        xcrun llvm-profdata merge ${PROFDATA_INPUT[@]} -output "${PROFDATA_OUTPUT}"
+
+        while IFS= read -r BINARY_PATH; do
+            (xcrun --run llvm-cov show "${BINARY_PATH}" --instr-profile "${PROFDATA_OUTPUT}") >> "${COVERAGE_OUTPUT}" || true
+        done <<< "$(find "${PRODUCTS_PATH}" -type f -name "*.o")"
+
+    - name: Capture Coverage Map
+      uses: actions/upload-artifact@v2
+      with:
+        name: Coverage.lcov
+        path: merged.lcov
+        if-no-files-found: warn
 
     - name: Select Java Release
       uses: actions/setup-java@v2
@@ -31,54 +94,6 @@ jobs:
 
     - name: Install Sonar Scanner
       run: brew install sonar-scanner
-
-    - name: Run Tests
-      run: |
-        DEVELOPER_PATH=$(xcode-select --print-path)
-        PLATFORM=$(ls -1 "${DEVELOPER_PATH}/Platforms/iPhoneOS.platform/DeviceSupport/" | sort -gr | head -n 1)
-        DEVICE=$(xcrun simctl list devices "iOS ${PLATFORM}" | grep "iPhone" | head -n 1 | sed -Ee 's/^.*\(([A-Z0-9\-]+)\).*$/\1/g')
-
-        xcodebuild test \
-          -project "Zone5.xcodeproj" \
-          -scheme "Zone5" \
-          -destination "platform=iOS Simulator,id=${DEVICE}" \
-          -enableCodeCoverage YES \
-          -derivedDataPath "${GITHUB_WORKSPACE}/DerivedData" \
-          CODE_SIGNING_REQUIRED=NO \
-          CODE_SIGN_IDENTITY=""
-
-    - name: Capture Logs
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-        name: Results
-        path: DerivedData/Logs/Test/*.xcresult
-        if-no-files-found: warn
-
-    - name: Merge Profile Data
-      run: |
-        PROFDATA_INPUT="${GITHUB_WORKSPACE}/DerivedData/Build/ProfileData/*/*.profdata"
-        PROFDATA_OUTPUT="${GITHUB_WORKSPACE}/merged.profdata"
-        xcrun llvm-profdata merge ${PROFDATA_INPUT[@]} -output "${PROFDATA_OUTPUT}"
-
-    - name: Prepare Coverage Report
-      run: |
-        PROFDATA_INPUT="${GITHUB_WORKSPACE}/merged.profdata"
-        COVERAGE_OUTPUT="${GITHUB_WORKSPACE}/merged.lcov"
-        BUNDLES="${GITHUB_WORKSPACE}/DerivedData/Build/Products/Debug-*/*"
-
-        for BUNDLE_PATH in ${BUNDLES}; do
-          if [[ -e "${BUNDLE_PATH}/Info.plist" ]]; then
-            PLIST_PATH="${BUNDLE_PATH}/Info.plist"
-          elif [[ -e "${BUNDLE_PATH}/Resources/Info.plist" ]]; then
-            PLIST_PATH="${BUNDLE_PATH}/Resources/Info.plist"
-          else
-            continue
-          fi
-
-          BINARY_NAME=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "${PLIST_PATH}")
-          (xcrun --run llvm-cov show "${BUNDLE_PATH}/${BINARY_NAME}" --instr-profile "${PROFDATA_INPUT}" || true) >> "${COVERAGE_OUTPUT}"
-        done
 
     - name: SonarCloud (Push)
       if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,35 +1,33 @@
-name: Generate Documentation
+name: Deploy Documentation
+
+# This workflow only runs when a release is created, if a draft is published as a release, or if a prerelease
+# is updated to a release (the prerelease checkbox is disabled).
+#
+# The `deploy-documentation` job also requires that the release has an asset named `Documentation.zip`,
+# otherwise the workflow itself will run, but the job will not.
 
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [released]
 
 jobs:
-  build:
-
-    runs-on: macOS-latest
+  deploy-documentation:
+    if: ${{ contains(github.event.release.assets.*.name, 'Documentation.zip') }}
+    runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v1
-    
-    - name: Cache RubyGems
-      uses: actions/cache@v1
+    - name: Download Documentation
+      uses: dsaltares/fetch-gh-release-asset@master
       with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: ${{ runner.os }}-gem-
+        file: Documentation.zip
+        version: ${{ github.event.release.id }}
+        target: ./Documentation.zip
 
-    - name: Generate Documentation
-      run: make documentation
+    - name: Decompress
+      run: unzip -o ./Documentation.zip -d ./docs
 
     - name: Deploy
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PUBLISH_BRANCH: gh-pages
-        PUBLISH_DIR: ./docs
-        SCRIPT_MODE: true
-      run: |
-        wget https://raw.githubusercontent.com/peaceiris/actions-gh-pages/v2.5.0/entrypoint.sh
-        bash ./entrypoint.sh
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+name: Release
+
+# This workflow only runs when a prerelease or release is created, if a prerelease or release is updated
+# (with changes to the releases title or notes AND a different commit), or if a prerelease is updated to a
+# release (the prerelease checkbox is disabled).
+#
+# The `xcframework` and `documentation` jobs will not run if the release already has an asset with the same
+# name as the one they generate.
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  xcframework:
+    if: ${{ !contains(github.event.release.assets.*.name, 'Zone5.xcframework.zip') }}
+    runs-on: macOS-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Build XCFramework
+      run: carthage build --verbose --use-xcframeworks --no-skip-current
+
+    - name: Create Archive
+      run: |
+        cd ./Carthage/Build
+        rm -rf "../../Zone5.xcframework.zip"
+        zip -qry "../../Zone5.xcframework.zip" "Zone5.xcframework"
+
+    - name: Upload Artifacts
+      uses: nanoufo/action-upload-artifacts-and-release-assets@v1.4
+      with:
+        path: Zone5.xcframework.zip
+        upload-release-files: true
+        release-upload-url: ${{ github.event.release.upload_url }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  documentation:
+    if: ${{ !contains(github.event.release.assets.*.name, 'Documentation.zip') }}
+    runs-on: macOS-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Cache RubyGems
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: ${{ runner.os }}-gem-
+
+    - name: "Set up SSH Agent"
+      uses: webfactory/ssh-agent@v0.5.4
+      with:
+        ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+    - name: "Add GitHub to SSH Known Hosts"
+      run: |
+        for ip in $(dig @8.8.8.8 github.com +short); do \
+          ssh-keyscan github.com,$ip; \
+          ssh-keyscan $ip; \
+        done 2>/dev/null >> ~/.ssh/known_hosts
+
+    - name: Build Documentation
+      run: make documentation
+
+    - name: Create Archive
+      run: |
+        cd ./docs
+        rm -rf "../Documentation.zip"
+        zip -qry "../Documentation.zip" . -i "*"      
+
+    - name: Upload Artifacts
+      uses: nanoufo/action-upload-artifacts-and-release-assets@v1.4
+      with:
+        path: Documentation.zip
+        upload-release-files: true
+        release-upload-url: ${{ github.event.release.upload_url }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+    # Update the hosted documentation if this is not a prerelease.
+    - name: Deploy
+      if: ${{ !github.event.release.prerelease }}
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs
+        

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Zone5.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Zone5.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1320"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Zone5"
+               BuildableName = "Zone5"
+               BlueprintName = "Zone5"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Zone5Tests"
+               BuildableName = "Zone5Tests"
+               BlueprintName = "Zone5Tests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Zone5Tests"
+               BuildableName = "Zone5Tests"
+               BlueprintName = "Zone5Tests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Zone5"
+            BuildableName = "Zone5"
+            BlueprintName = "Zone5"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.xcworkspace
+++ b/Package.xcworkspace
@@ -1,0 +1,1 @@
+.swiftpm/xcode/package.xcworkspace

--- a/README.md
+++ b/README.md
@@ -69,27 +69,12 @@ apiClient.notificationCenter.addObserver(forName: Zone5.updatedTermsNotification
 }
 ```
 
-Once configured, you'll be able to authenticate users via the methods available through [`Zone5.shared.oAuth.accessToken`](https://zone5-cloud.github.io/z5-sdk-swift/Classes/OAuthView.html) and [`Zone5.shared.users.login`](https://zone5-cloud.github.io/z5-sdk-swift/Classes/UsersView):
+Once configured, you'll be able to authenticate users via the methods available through [`Zone5.shared.users.login`](https://zone5-cloud.github.io/z5-sdk-swift/Classes/UsersView) and [`Zone5.shared.oAuth.accessToken`](https://zone5-cloud.github.io/z5-sdk-swift/Classes/OAuthView.html):
 
 ```swift
 let username = "EXAMPLE-USERNAME"
 let password = "EXAMPLE-PASSWORD"
 
-Zone5.shared.oAuth.accessToken(username: username, password: password) { result in
-	switch result {
-	case .failure(let error):
-		// An error occurred and needs to be handled
-
-	case .success(let accessToken):
-		// The user was successfully authenticated. 
-		// Your configured accessToken has automatically been updated and the `Zone5.authTokenChangedNotification` Notification fired
-	}
-}
-```
-
-or
-
-```swift
 Zone5.shared.users.login(email: username, password: password, accept: []) { result in
 	switch result {
     case .failure(let error):
@@ -99,6 +84,21 @@ Zone5.shared.users.login(email: username, password: password, accept: []) { resu
         // The user was successfully authenticated. loginResponse contains some user data including roles, identities, updatedTerms etc
         // Your configured accessToken has automatically been updated and the `Zone5.authTokenChangedNotification` Notification fired
     }
+}
+```
+
+or
+
+```swift
+Zone5.shared.oAuth.accessToken(username: username, password: password) { result in
+	switch result {
+	case .failure(let error):
+		// An error occurred and needs to be handled
+
+	case .success(let accessToken):
+		// The user was successfully authenticated. 
+		// Your configured accessToken has automatically been updated and the `Zone5.authTokenChangedNotification` Notification fired
+	}
 }
 ```
 
@@ -116,7 +116,23 @@ Zone5.shared.users.me { result in
 }
 ```
 
-Unauthenticated calls do not require the user to be logged in. These calls include things like Zone5.shared.terms.required, Zone5.shared.users.isEmailRegistered, Zone5.shared.users.register, Zone5.shared.users.resetPassword.
+Unauthenticated calls do not require the user to be logged in. These calls include things like Zone5.shared.terms.required, Zone5.shared.users.isEmailRegistered, Zone5.shared.users.register, Zone5.shared.users.resetPassword. See https://zone5-cloud.github.io/z5-sdk-swift/Classes/UsersView and https://zone5-cloud.github.io/z5-sdk-swift/Classes/TermsView for details on using these methods.
+
+A basic usage for a registration screen may be:
+* Call Zone5.shared.terms.required to retrieve the required Terms and Conditions. If the Terms are hosted at an external URL (such as the Specialized Terms of Use), then the response will include the URL of the Terms Content.
+* Call Zone5.shared.users.isEmailRegistered once a user has entered a registration email so that the UI can provide feedback that this user already exists.
+* Offer an option for the user to reset their existing password that calls Zone5.shared.users.resetPassword
+* Call Zone5.shared.users.register to register a new user in the system. Don't let the user register until they have accepted terms and conditions. Make sure you pass the list of accepted Terms and Conditions ids into register
+
+A basic usahe for a login screen may be:
+* Offer an option for the user to reset their existing password that calls Zone5.shared.users.resetPassword
+* Call the above mentioned [`Zone5.shared.users.login`](https://zone5-cloud.github.io/z5-sdk-swift/Classes/UsersView) with the user's credentials
+* If the login fails due to there being new, unaccepted Terms and Conditions
+    * call Zone5.shared.terms.required and present new terms (by URL or by calling Zone5.shared.terms.download (SBC terms are by URL)
+    * retry [`Zone5.shared.users.login`](https://zone5-cloud.github.io/z5-sdk-swift/Classes/UsersView), passing in new accepted terms
+* If the login succeeds but the login response includes updated terms, present new terms (SBC terms are by URL)
+    * call Zone5.shared.terms.accept to accept the updated terms
+
 
 ## Unit Tests
 


### PR DESCRIPTION
As requested, here are a number of improvements to the GitHub Action workflows, as utilised by the most recent versions of the RideRecorder and ExternalSensor projects. This brings a number of benefits:

- Unit tests are run for both the `Zone5.xcodeproj`, and the Swift Package, with the `.xcresult` bundles and lcov report captured as workflow artifacts.
- On publishing releases, an XCFramework and the relevant documentation are pre-built and attached to the release, which is useful for integrating with Carthage.
- If available, documentation is published to the GitHub Pages branch from the pre-built version when a tag moves from prerelease to release. This helps reduce the amount of time spent building and parsing the source for generating documentation.

As much as possible, I've tested these updates locally, and they've also been tested with the other projects.