### PR TITLE
[TACO-1476] Add purge account endpoint

### DIFF
--- a/Zone5/Views/UsersView.swift
+++ b/Zone5/Views/UsersView.swift
@@ -19,6 +19,7 @@ public class UsersView: APIView {
 		case passwordComplexity = "/rest/auth/password-complexity"
 		case reconfirmEmail = "/rest/auth/reconfirm"
 		case testPassword = "/rest/auth/test-password"
+		case purgeAccount = "/purge/api/v1/request"
 
 		var requiresAccessToken: Bool {
 			switch self {
@@ -50,6 +51,13 @@ public class UsersView: APIView {
 	public func deleteAccount(userID: Int, completion: @escaping Zone5.ResultHandler<Zone5.VoidReply>) -> PendingRequest? {
 		let endpoint = Endpoints.deleteUser.replacingTokens(["userID": userID])
 		return get(endpoint, with: completion)
+	}
+	
+	/// Purge (soft delete) a user account
+	@discardableResult
+	public func purgeAccount(_ completion: @escaping Zone5.ResultHandler<Zone5.VoidReply>) -> PendingRequest? {
+		let endpoint = Endpoints.purgeAccount
+		return post(endpoint, body: nil, with: completion)
 	}
 	
 	/// Login as a user and obtain a bearer token

--- a/Zone5Tests/Views/UsersViewTests.swift
+++ b/Zone5Tests/Views/UsersViewTests.swift
@@ -714,4 +714,26 @@ class UsersViewTests: XCTestCase {
 
         wait(for: expectations, timeout: 5)
 	}
+
+	func testPurgeAccount() {
+		let tests: [Result<Zone5.VoidReply, Zone5.Error>] = [(
+			.success(Zone5.VoidReply())
+		)]
+		var expectations: [XCTestExpectation] = []
+		execute(with: tests) { client, _, urlSession, expectedResult in
+			urlSession.dataTaskHandler = { request in
+				XCTAssertEqual(request.url?.path, "/purge/api/v1/request")
+				XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer ACCESS_TOKEN")
+				XCTAssertNil(request.httpBody)
+				XCTAssertEqual(request.httpMethod, "POST")
+				return .success("")
+			}
+
+			let expectation = ResultExpectation(for: expectedResult)
+			expectations.append(expectation)
+
+			client.users.purgeAccount(expectation.fulfill)
+		}
+		wait(for: expectations, timeout: 5)
+	}
 }


### PR DESCRIPTION
### What?
<!-- Explaining the changes at a high level, pointing out the overall effect. -->
Adds the purge account endpoint to the SDK
### Why?
<!-- Business Objective/Goals. -->
To allow us to conform to the App Store guidelines 

### How?
<!-- Draw attention to the significant decisions that help the reviewer to understand the reasoning in the logic. -->
Implemented the end point

### Testing Plan
<!--- Include repro steps and all possible flows to validate functionality --->
- I tested this by pulling this branch into the ride app, created a burner account, then sending the request to delete the burner account. After the request responded as successful, I would attempt to sign into the burner account again and see that I was denied. 


### Metadata
- Ticket(s): [TACO-1476](https://jira.specialized.com/browse/TACO-1476)
- Relevant Design(s):
