### PR TITLE
OP-1106 Optionally ask for ios native url for strava pairing

### DIFF
--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -31,6 +31,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>37</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array><string>strava</string></array>	
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/Zone5/Users/User.swift
+++ b/Zone5/Users/User.swift
@@ -29,7 +29,7 @@ public struct User: Searchable, JSONEncodedBody {
 	
 	public var identities: [String: String]?
 	
-	public var weight: Int?
+	public var weight: Double?
 	
 	public var gender: String?
 	

--- a/Zone5/Views/ThirdPartyConnectionsView.swift
+++ b/Zone5/Views/ThirdPartyConnectionsView.swift
@@ -99,7 +99,7 @@ public class ThirdPartyConnectionsView: APIView {
 		return get(Endpoints.userConnections, parameters: nil, expectedType: [ThirdPartyResponse].self) { result in
 			switch result {
 			case .success(let connections):
-				let connectedTypes: [UserConnectionType] = UserConnectionType.allCases.filter({ t in connections.first(where: { $0.type == t.connectionName && $0.enabled == true }) != nil })
+				let connectedTypes: [UserConnectionType] = UserConnectionType.allCases.filter({ t in connections.first(where: { $0.type == t.connectionName && $0.enabled }) != nil })
 				completion(.success(connectedTypes))
 			case .failure(let error):
 				completion(.failure(error))

--- a/Zone5/Views/ThirdPartyConnectionsView.swift
+++ b/Zone5/Views/ThirdPartyConnectionsView.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 public class ThirdPartyConnectionsView: APIView {
 	private enum Endpoints: String, InternalRequestEndpoint {
@@ -61,9 +62,15 @@ public class ThirdPartyConnectionsView: APIView {
 	/// - redirect: the URL that the user will be redirected back to on completion of third party authentication
 	/// - Returns a reponse containing a thrid party authentication URL. Open this link in a browser so the user can authenticate with the third party. On completion the user will be redirected back to the passed in redirect URL
 	@discardableResult
+	@available(iOSApplicationExtension, unavailable)
 	public func pairThirdPartyConnection(type: UserConnectionType, redirect: URL, completion: @escaping Zone5.ResultHandler<String>) -> PendingRequest? {
 		let endpoint = Endpoints.connectService.replacingTokens(["connectionType": type.connectionName])
-		return get(endpoint, parameters: ["redirect-uri": redirect.absoluteString], with: completion)
+		
+		if type == .strava, UIApplication.shared.canOpenURL(URL(string: "strava://")!) {
+			return get(endpoint, parameters: ["redirect-uri": redirect.absoluteString, "platform": "ios"], with: completion)
+		} else {
+			return get(endpoint, parameters: ["redirect-uri": redirect.absoluteString], with: completion)
+		}
 	}
 	
 	/// Checks if a connection type is enabled or not
@@ -79,6 +86,21 @@ public class ThirdPartyConnectionsView: APIView {
 				}
 				
 				completion(.success(true))
+			case .failure(let error):
+				completion(.failure(error))
+			}
+		}
+	}
+	
+	/// Returns list of connected third party types
+	/// - Parameters
+	@discardableResult
+	public func enabledThirdPartyConnections(completion: @escaping Zone5.ResultHandler<[UserConnectionType]>) -> PendingRequest? {
+		return get(Endpoints.userConnections, parameters: nil, expectedType: [ThirdPartyResponse].self) { result in
+			switch result {
+			case .success(let connections):
+				let connectedTypes: [UserConnectionType] = UserConnectionType.allCases.filter({ t in connections.first(where: { $0.type == t.connectionName && $0.enabled == true }) != nil })
+				completion(.success(connectedTypes))
 			case .failure(let error):
 				completion(.failure(error))
 			}


### PR DESCRIPTION
The Staging backend has been updated to take an optional parameter on Third Party pairing to specify ios native scheme when pairing with Strava. You only want to use this option if Strava app is installed. This is now checked as part of the sdk method. 

Not sure if Taco is using z5-sdk-swift or not. If not, use similar code as to what is in this PR.

note the Info.plist addition and the available annotation that are both required to make canOpenURL work.